### PR TITLE
When hash validation fails, show the expected hash vs actual hash.

### DIFF
--- a/src/nyaa/build.nim
+++ b/src/nyaa/build.nim
@@ -75,10 +75,11 @@ proc builder(package: string, destdir: string,
             waitFor download(i.replace("$VERSION", pkg.version), filename)
         except:
             raise
-
-        if sha256hexdigest(readAll(open(filename)))&"  "&filename !=
-                pkg.sha256sum.split(";")[int]:
-            err "sha256sum doesn't match for "&i
+        
+        var expectedDigest = sha256hexdigest(readAll(open(filename)))&"  "&filename
+        var actualDigest = pkg.sha256sum.split(";")[int]
+        if expectedDigest != actualDigest:
+            err "sha256sum doesn't match for "&i&"\nExpected: "&expectedDigest&"\nActual: "&actualDigest
 
         int = int+1
 

--- a/src/nyaa/build.nim
+++ b/src/nyaa/build.nim
@@ -76,8 +76,8 @@ proc builder(package: string, destdir: string,
         except:
             raise
         
-        var expectedDigest = sha256hexdigest(readAll(open(filename)))&"  "&filename
-        var actualDigest = pkg.sha256sum.split(";")[int]
+        var actualDigest = sha256hexdigest(readAll(open(filename)))&"  "&filename
+        var expectedDigest = pkg.sha256sum.split(";")[int]
         if expectedDigest != actualDigest:
             err "sha256sum doesn't match for "&i&"\nExpected: "&expectedDigest&"\nActual: "&actualDigest
 


### PR DESCRIPTION
Useful for debugging why sha256 validation is failing.